### PR TITLE
Fixing broken link

### DIFF
--- a/indicngram/templates/indicngram.html
+++ b/indicngram/templates/indicngram.html
@@ -66,7 +66,7 @@
 <p>An n-gram model is a type of probabilistic model for predicting the next item in a sequence. n-grams are used in various areas of statistical natural language processing and genetic sequence analysis.
 An n-gram is a subsequence of n items from a given sequence. The items in question can be phonemes, syllables, letters, words or base pairs according to the application.
 An n-gram of size 1 is referred to as a "unigram"; size 2 is a "bigram" (or, less commonly, a "digram"); size 3 is a "trigram"; and size 4 or more is simply called an "n-gram".</p>
-<p>If you want to use this library in your program , you may refer the JSON-RPC based <a href="apis.html#NGram">API documentation.</a></p>
+<p>If you want to use this library in your program , you may refer the JSON-RPC based <a href="http://silpa.readthedocs.org/en/latest/apis.html">API documentation.</a></p>
 <a href="http://en.wikipedia.org/wiki/N-gram">Read more about N-gram</a>
 
 <h4>Supported Languages</h4>


### PR DESCRIPTION
The API documentation in the ngrams page at libindic.org is broken. This is a fix which makes it point to readthedocs documentation of the API.
