### PR TITLE
Make libindic a namespace package

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,4 +1,4 @@
 [DEFAULT]
-test_command=${PYTHON:-python} -m subunit.run discover libindic/ngram $LISTOPT $IDOPTION
+test_command=${PYTHON:-python} -m subunit.run discover libindic $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 travis:
 	python setup.py test --coverage \
-		--coverage-package-name=libindic.ngram
+		--coverage-package-name=ngram
 	flake8 --max-complexity 10 libindic/ngram
 
 clean:

--- a/libindic/ngram/tests/test_indicngram.py
+++ b/libindic/ngram/tests/test_indicngram.py
@@ -2,14 +2,15 @@
 # -*- coding: utf-8 -*-
 
 from testtools import TestCase
-from libindic import ngram
+
+from .. import Ngram
 
 
 class IndicNgramTest(TestCase):
 
     def setUp(self):
         super(IndicNgramTest, self).setUp()
-        self.ngram = ngram.Ngram()
+        self.ngram = Ngram()
 
     def test_letterNgram_English(self):
         self.assertEqual(self.ngram.letterNgram("catterpillar"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
   Programming Language :: Python :: 3
 
 [files]
+namespace_packages = libindic
 packages = libindic
 
 [build-sphinx]


### PR DESCRIPTION
Our requirement of `libindic.module` can be satisfied without using another top-level package. As per PEP420, we can use namespace packages for that.
